### PR TITLE
Support for the pendant v3 resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 __pycache__
 server/internal/configuration.json
+.idea

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The purpose of this project is to provide users with a framework upon which they
 ## MQTT Broker Setup (Mosquitto)
 ### Windows
 1. Download the exe from here: https://mosquitto.org/download/
-2. Locate your `mosqutto.conf`. This will be `C:\Program Files\mosquitto\mosquitto.conf` or `C:\Program Files (x86)\mosquitto\mosquitto.conf`.
+2. Locate your `mosquitto.conf`. This will be `C:\Program Files\mosquitto\mosquitto.conf` or `C:\Program Files (x86)\mosquitto\mosquitto.conf`.
 3. Insert the following at the beginning of the "Listeners" section:
 ```txt
 allow_anonymous true

--- a/client/index.html
+++ b/client/index.html
@@ -32,7 +32,7 @@
                   <div class="content-panel-body" id="general-configuration-editor-container">
                     <div id="general-configuration-editor"></div>
                     <div>
-                      
+
                       <div class="content-panel-button-group">
                         <button class="content-panel-button start-button" id="run-start-button">
                           <span class="fa fa-play"></span><div>START</div>
@@ -61,7 +61,7 @@
                 </div>
               </div>
             </div>
-           
+
             <div class="v_layout" style="height: 100%;width: 50%; flex: auto;">
               <div class="content-panel">
                 <div class="content-panel-header">
@@ -69,7 +69,6 @@
                 </div>
                 <div class="content-panel-body" id="custom-container">
                 </div>
-              </div>
               </div>
             </div>
           </div>

--- a/client/styles/index.css
+++ b/client/styles/index.css
@@ -24,8 +24,12 @@ body {
 }
 
 #app-wrapper {
+    width: 100%;
     height: 100%;
-    width: 1280px;
+    min-width: 1280px;
+    min-height: 800px;
+    max-width: 1920px;
+    max-height: 1080px;
     display: flex;
     flex-direction: column;
     font-size: 16px;
@@ -33,7 +37,6 @@ body {
     margin-left: auto;
     margin-right: auto;
     position: relative;
-    height: 800px;
 }
 
 #app-wrapper > header {
@@ -320,9 +323,10 @@ main {
 .content-panel-button-group {
     text-align: center;
     display: flex;
-    justify-content: space-evenly;
+    justify-content: center;
     padding: 0.5rem;
     align-items: center;
+    column-gap: 6px;
 }
 
 .content-panel-body {
@@ -479,7 +483,7 @@ main {
     -ms-user-select: none;
     user-select: none;
 }
-  
+
 .widget-checkbox input {
     position: absolute;
     opacity: 0;
@@ -502,21 +506,21 @@ main {
 .widget-checkbox:hover input ~ .widget-checkmark {
     background-color: var(--offwhite-color);
 }
-  
+
 .widget-checkbox input:checked ~ .widget-checkmark {
     background-color: var(--success-color);
 }
-  
+
 .widget-checkmark:after {
     content: "";
     position: absolute;
     display: none;
 }
-  
+
 .widget-checkbox input:checked ~ .widget-checkmark:after {
     display: block;
 }
-  
+
 .widget-checkbox .widget-checkmark:after {
     left: 0.3rem;
     top: 0.15rem;
@@ -650,7 +654,7 @@ main {
 .widget-button {
     padding: 1rem;
     background-color: var(--primary-color);
-    color: --offwhite-color;
+    color: var(--offwhite-color);
     font-size: 16px;
     border-radius: 3px;
 }

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,15 @@
+# Upload your new program to the server
+echo '****************************************************************'
+echo '**************** Uploading your Machine App ********************'
+echo '******** You will be prompted to enter your password ***********'
+echo '******************** Password is: temppwd ***********************'
+echo '****************************************************************'
+echo 'Uploading your server/internal program to the MachineMotion...'
+scp ./server/internal/*.py debian@192.168.7.2:/var/lib/cloud9/mm-machineapp-template/server/internal
+echo 'Internal upload complete.'
+echo 'Uploading your server program to the MachineMotion...'
+scp ./server/*.py debian@192.168.7.2:/var/lib/cloud9/mm-machineapp-template/server
+echo 'Server upload complete.'
+echo 'Uploading your client program to the MachineMotion...'
+scp -r ./client/* debian@192.168.7.2:/var/lib/cloud9/mm-machineapp-template/client
+echo 'Client upload complete.'


### PR DESCRIPTION
# Issues
fixes https://github.com/VentionCo/mm-vention-control/issues/3985

# What's new
- Scale to the page between the pendant V2 (1280x800) and pendant V3 resolution (1920x1080)
- Added a shell script because scp through python didn't work for me.

# What did I test?
- Uploaded the template
- Looks nice

# Screenshots
### Pendant V3
![image](https://user-images.githubusercontent.com/104782888/221995460-0df8da04-79bd-4d3a-9ac1-9b0481eff7aa.png)

### Pendant V2
![image](https://user-images.githubusercontent.com/104782888/221995590-f8494067-ec90-422a-842a-657dae1e52cb.png)
